### PR TITLE
Add support to Elliptic-curve cryptography keys

### DIFF
--- a/src/Data/X509/PKCS10.hs
+++ b/src/Data/X509/PKCS10.hs
@@ -236,14 +236,9 @@ instance ASN1Object Signature where
 
 instance ASN1Object ECC.Signature where
   toASN1 (ECC.Signature r s) xs =
-      [ Start Sequence
-      , IntVal (r)
-      , IntVal (s)
-      , End Sequence
-      ]
+    (IntVal r) : (IntVal s) : xs
 
-  fromASN1 (Start Sequence : xs) = do
-    let (IntVal r: IntVal s:x) = xs
+  fromASN1 (IntVal r : IntVal s : xs) = do
     Right (ECC.Signature r s, xs)
 
   fromASN1 _ = Left "fromASN1: PKCS9.CertificationRequestInfo: unknown format"

--- a/src/Data/X509/PKCS10.hs
+++ b/src/Data/X509/PKCS10.hs
@@ -447,7 +447,7 @@ instance ASN1Object ECC.Signature where
   fromASN1 (Start Sequence : IntVal r : IntVal s : End Sequence : xs) =
     Right (ECC.Signature { ECC.sign_r = r, ECC.sign_s = s }, xs)
 
-  fromASN1 _ = Left "fromASN1: DSA.Signature: unknown format"
+  fromASN1 _ = Left "fromASN1: ECC.Signature: unknown format"
   
 -- | Generate CSR.
 generateCSR :: (MonadRandom m, HashAlgorithmConversion hashAlg, HashAlgorithm hashAlg) => X520Attributes -> PKCS9Attributes -> KeyPair -> hashAlg -> m (Either Error CertificationRequest)


### PR DESCRIPTION
Updates
1) Add ECC keypair
2) Implemented GenerateCSR method for ECC
3) Supports all the curves from `cryptonite` lib